### PR TITLE
fix: typo in ghcr image address

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/owasp-dep-scan/dep-scan:release/5.x"
+  image: "docker://ghcr.io/owasp-dep-scan/dep-scan:release-5.x"
   args:
     - "--src"
     - ${{ inputs.src }}


### PR DESCRIPTION
fix typo in ghcr image address to address Github Action error Docker pull failed with exit code  1.