### PR TITLE
Fix image tag format in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/owasp-dep-scan/dep-scan:release/5.x"
+  image: "docker://ghcr.io/owasp-dep-scan/dep-scan:release-5.x"
   args:
     - "--src"
     - ${{ inputs.src }}


### PR DESCRIPTION
Fix for:

```
Warning: Docker pull failed with exit code 1, back off 1.341 seconds before retry.
/usr/bin/docker pull ghcr.io/owasp-dep-scan/dep-scan:release/5.x invalid reference format
Error: Docker pull failed with exit code 1
```